### PR TITLE
Remove votechoices from setVoteChoices response.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -69,9 +69,14 @@ the expiration time has passed.
 Provide the voting key for the ticket, voting preference, and a signed
 transaction which pays the fee to the specified address. If the fee has expired,
 this call will return an error and the client will need to request a new fee by
-calling `/feeaddress` again. The VSP will not broadcast the fee transaction
-until the ticket purchase has 6 confirmations, and it will not add the ticket to
-its voting wallets until the fee transaction has 6 confirmations.
+calling `/feeaddress` again.
+
+The VSP will not broadcast the fee transaction until the ticket purchase has 6
+confirmations. For this reason, it is important that the client ensures the
+output being spent in the transaction is not spent elsewhere.
+
+The VSP will not add the ticket to its voting wallets until the fee transaction
+has 6 confirmations.
 
 - `POST /payfee`
 
@@ -149,7 +154,6 @@ after calling `/payfee`.
     ```json
     {
       "timestamp":1590509066,
-      "votechoices":{"headercommitments":"no"},
       "request": {"<Copy of request body>"}
     }
     ```

--- a/webapi/setvotechoices.go
+++ b/webapi/setvotechoices.go
@@ -72,8 +72,7 @@ func setVoteChoices(c *gin.Context) {
 	// TODO: DB - store setvotechoices receipt in log
 
 	sendJSONResponse(setVoteChoicesResponse{
-		Timestamp:   time.Now().Unix(),
-		Request:     setVoteChoicesRequest,
-		VoteChoices: voteChoices,
+		Timestamp: time.Now().Unix(),
+		Request:   setVoteChoicesRequest,
 	}, c)
 }

--- a/webapi/types.go
+++ b/webapi/types.go
@@ -43,9 +43,8 @@ type SetVoteChoicesRequest struct {
 }
 
 type setVoteChoicesResponse struct {
-	Timestamp   int64                 `json:"timestamp" binding:"required"`
-	Request     SetVoteChoicesRequest `json:"request" binding:"required"`
-	VoteChoices map[string]string     `json:"votechoices" binding:"required"`
+	Timestamp int64                 `json:"timestamp" binding:"required"`
+	Request   SetVoteChoicesRequest `json:"request" binding:"required"`
 }
 
 type TicketStatusRequest struct {


### PR DESCRIPTION
No need for it. The response already contains the whole request, which contains the vote choices.